### PR TITLE
Organize cover templates under cover domain

### DIFF
--- a/home-assistant-config/configuration.yaml
+++ b/home-assistant-config/configuration.yaml
@@ -21,11 +21,13 @@ automation: !include automations.yaml
 script: !include scripts.yaml
 
 # Covers
-cover: !include covers/cover_groups.yaml
+cover:
+  - !include covers/cover_groups.yaml
+  - platform: template
+    covers: !include templates/cover_templates.yaml
 
 # Capteurs
 template:
-  - !include templates/cover_templates.yaml
   - !include templates/sensor_pac.yaml
 
 # Groupe spécifique à l'iPad

--- a/home-assistant-config/configuration.yaml
+++ b/home-assistant-config/configuration.yaml
@@ -21,10 +21,10 @@ automation: !include automations.yaml
 script: !include scripts.yaml
 
 # Covers
-cover:
-  - !include covers/cover_groups.yaml
-  - platform: template
-    covers: !include templates/cover_templates.yaml
+cover: !include_dir_merge_list covers
+
+# Template sensors
+template: !include templates/climate_sensors.yaml
 
 # Groupe spécifique à l'iPad
 group:

--- a/home-assistant-config/configuration.yaml
+++ b/home-assistant-config/configuration.yaml
@@ -26,10 +26,6 @@ cover:
   - platform: template
     covers: !include templates/cover_templates.yaml
 
-# Capteurs
-template:
-  - !include templates/sensor_pac.yaml
-
 # Groupe spécifique à l'iPad
 group:
   ipad_dashboard:

--- a/home-assistant-config/covers/cover_groups.yaml
+++ b/home-assistant-config/covers/cover_groups.yaml
@@ -1,4 +1,19 @@
 - platform: group
-  name: "All Covers"
+  name: "cover_volets_tous"
   entities:
-    - cover.example_cover
+    - cover.volet_salon
+    - cover.volet_cuisine
+    - cover.volet_chambre1
+    - cover.volet_chambre2
+
+- platform: group
+  name: "cover_volets_rdc"
+  entities:
+    - cover.volet_salon
+    - cover.volet_cuisine
+
+- platform: group
+  name: "cover_volets_chambres"
+  entities:
+    - cover.volet_chambre1
+    - cover.volet_chambre2

--- a/home-assistant-config/covers/cover_groups.yaml
+++ b/home-assistant-config/covers/cover_groups.yaml
@@ -1,19 +1,42 @@
 - platform: group
-  name: "cover_volets_tous"
+  name: Tous les volets
+  unique_id: cover_volets_tous
   entities:
-    - cover.volet_salon
-    - cover.volet_cuisine
-    - cover.volet_chambre1
-    - cover.volet_chambre2
+    - cover.fenetre_adele_arriere
+    - cover.fenetre_adele_ru
+    - cover.fenetre_alex_jar
+    - cover.fenetre_alex_rue
+    - cover.fenetre_bureau
+    - cover.fenetre_cuisine
+    - cover.fenetre_cuisine_avant
+    - cover.fenetre_entree
+    - cover.fenetre_salon_central
+    - cover.fenetre_salon_dr
+    - cover.fenetre_salon_gauche
+    - cover.fenetre_salon_tv
+    - cover.fenetre_sdb_suite
+    - cover.fenetre_suite
 
 - platform: group
-  name: "cover_volets_rdc"
+  name: Volets RDC
+  unique_id: cover_volets_rdc
   entities:
-    - cover.volet_salon
-    - cover.volet_cuisine
+    - cover.fenetre_cuisine
+    - cover.fenetre_cuisine_avant
+    - cover.fenetre_entree
+    - cover.fenetre_salon_central
+    - cover.fenetre_salon_dr
+    - cover.fenetre_salon_gauche
+    - cover.fenetre_salon_tv
 
 - platform: group
-  name: "cover_volets_chambres"
+  name: Volets Chambres
+  unique_id: cover_volets_chambres
   entities:
-    - cover.volet_chambre1
-    - cover.volet_chambre2
+    - cover.fenetre_adele_arriere
+    - cover.fenetre_adele_ru
+    - cover.fenetre_alex_jar
+    - cover.fenetre_alex_rue
+    - cover.fenetre_bureau
+    - cover.fenetre_sdb_suite
+    - cover.fenetre_suite

--- a/home-assistant-config/covers/cover_groups.yaml
+++ b/home-assistant-config/covers/cover_groups.yaml
@@ -1,0 +1,4 @@
+- platform: group
+  name: "All Covers"
+  entities:
+    - cover.example_cover

--- a/home-assistant-config/covers/templates.yaml
+++ b/home-assistant-config/covers/templates.yaml
@@ -1,0 +1,2 @@
+- platform: template
+  covers: !include ../templates/cover_templates.yaml

--- a/home-assistant-config/templates/climate_sensors.yaml
+++ b/home-assistant-config/templates/climate_sensors.yaml
@@ -1,0 +1,104 @@
+- sensor:
+    - name: 'Info Climat Adèle'
+      unique_id: 'info_climat_adele'
+      state: >
+        {% set climate = states('climate.adele') %}
+        {% set temp = state_attr('climate.adele', 'current_temperature') | float %}
+        {% set target = state_attr('climate.adele', 'temperature') | float %}
+        {% if temp > 0 %}
+          {{ temp }}°C
+        {% else %}
+          N/A
+        {% endif %}
+      attributes:
+        temperature: >
+          {{ state_attr('climate.adele', 'current_temperature') | float }}
+        target_temperature: >
+          {{ state_attr('climate.adele', 'temperature') | float }}
+        climate_state: >
+          {{ states('climate.adele') }}
+
+    - name: 'Info Climat Alex'
+      unique_id: 'info_climat_alex'
+      state: >
+        {% set temp = state_attr('climate.alex', 'current_temperature') | float %}
+        {% if temp > 0 %}
+          {{ temp }}°C
+        {% else %}
+          N/A
+        {% endif %}
+      attributes:
+        temperature: >
+          {{ state_attr('climate.alex', 'current_temperature') | float }}
+        target_temperature: >
+          {{ state_attr('climate.alex', 'temperature') | float }}
+        climate_state: >
+          {{ states('climate.alex') }}
+
+    - name: 'Info Climat Bureau'
+      unique_id: 'info_climat_bureau'
+      state: >
+        {% set temp = state_attr('climate.bureau', 'current_temperature') | float %}
+        {% if temp > 0 %}
+          {{ temp }}°C
+        {% else %}
+          N/A
+        {% endif %}
+      attributes:
+        temperature: >
+          {{ state_attr('climate.bureau', 'current_temperature') | float }}
+        target_temperature: >
+          {{ state_attr('climate.bureau', 'temperature') | float }}
+        climate_state: >
+          {{ states('climate.bureau') }}
+
+    - name: 'Info Climat Cuisine'
+      unique_id: 'info_climat_cuisine'
+      state: >
+        {% set temp = state_attr('climate.cuisine', 'current_temperature') | float %}
+        {% if temp > 0 %}
+          {{ temp }}°C
+        {% else %}
+          N/A
+        {% endif %}
+      attributes:
+        temperature: >
+          {{ state_attr('climate.cuisine', 'current_temperature') | float }}
+        target_temperature: >
+          {{ state_attr('climate.cuisine', 'temperature') | float }}
+        climate_state: >
+          {{ states('climate.cuisine') }}
+
+    - name: 'Info Climat Entrée'
+      unique_id: 'info_climat_entree'
+      state: >
+        {% set temp = state_attr('climate.entree_tv', 'current_temperature') | float %}
+        {% if temp > 0 %}
+          {{ temp }}°C
+        {% else %}
+          N/A
+        {% endif %}
+      attributes:
+        temperature: >
+          {{ state_attr('climate.entree_tv', 'current_temperature') | float }}
+        target_temperature: >
+          {{ state_attr('climate.entree_tv', 'temperature') | float }}
+        climate_state: >
+          {{ states('climate.entree_tv') }}
+
+    - name: 'Info Climat Parents'
+      unique_id: 'info_climat_parents'
+      state: >
+        {% set temp = state_attr('climate.parents', 'current_temperature') | float %}
+        {% if temp > 0 %}
+          {{ temp }}°C
+        {% else %}
+          N/A
+        {% endif %}
+      attributes:
+        temperature: >
+          {{ state_attr('climate.parents', 'current_temperature') | float }}
+        target_temperature: >
+          {{ state_attr('climate.parents', 'temperature') | float }}
+        climate_state: >
+          {{ states('climate.parents') }}

--- a/home-assistant-config/templates/cover_templates.yaml
+++ b/home-assistant-config/templates/cover_templates.yaml
@@ -1,50 +1,53 @@
-- name: "Volets (Tous)"
+volets_tous:
+  friendly_name: "Volets (Tous)"
   unique_id: "template_volets_tous"
   device_class: shutter
-  state: "{{ is_state('cover.cover_volets_tous', 'open') }}"
+  value_template: "{{ is_state('cover.tous_les_volets', 'open') }}"
   open_cover:
-    - service: cover.open_cover
-      target:
-        entity_id: cover.cover_volets_tous
+    service: cover.open_cover
+    target:
+      entity_id: cover.tous_les_volets
   close_cover:
-    - service: cover.close_cover
-      target:
-        entity_id: cover.cover_volets_tous
+    service: cover.close_cover
+    target:
+      entity_id: cover.tous_les_volets
   stop_cover:
-    - service: cover.stop_cover
-      target:
-        entity_id: cover.cover_volets_tous
+    service: cover.stop_cover
+    target:
+      entity_id: cover.tous_les_volets
 
-- name: "Volets (RDC)"
+volets_rdc:
+  friendly_name: "Volets (RDC)"
   unique_id: "template_volets_rdc"
   device_class: shutter
-  state: "{{ is_state('cover.cover_volets_rdc', 'open') }}"
+  value_template: "{{ is_state('cover.volets_rdc', 'open') }}"
   open_cover:
-    - service: cover.open_cover
-      target:
-        entity_id: cover.cover_volets_rdc
+    service: cover.open_cover
+    target:
+      entity_id: cover.volets_rdc
   close_cover:
-    - service: cover.close_cover
-      target:
-        entity_id: cover.cover_volets_rdc
+    service: cover.close_cover
+    target:
+      entity_id: cover.volets_rdc
   stop_cover:
-    - service: cover.stop_cover
-      target:
-        entity_id: cover.cover_volets_rdc
+    service: cover.stop_cover
+    target:
+      entity_id: cover.volets_rdc
 
-- name: "Volets (Chambres)"
+volets_chambres:
+  friendly_name: "Volets (Chambres)"
   unique_id: "template_volets_chambres"
   device_class: shutter
-  state: "{{ is_state('cover.cover_volets_chambres', 'open') }}"
+  value_template: "{{ is_state('cover.volets_chambres', 'open') }}"
   open_cover:
-    - service: cover.open_cover
-      target:
-        entity_id: cover.cover_volets_chambres
+    service: cover.open_cover
+    target:
+      entity_id: cover.volets_chambres
   close_cover:
-    - service: cover.close_cover
-      target:
-        entity_id: cover.cover_volets_chambres
+    service: cover.close_cover
+    target:
+      entity_id: cover.volets_chambres
   stop_cover:
-    - service: cover.stop_cover
-      target:
-        entity_id: cover.cover_volets_chambres
+    service: cover.stop_cover
+    target:
+      entity_id: cover.volets_chambres

--- a/home-assistant-config/templates/cover_templates.yaml
+++ b/home-assistant-config/templates/cover_templates.yaml
@@ -1,0 +1,10 @@
+example_cover:
+  friendly_name: "Example Cover"
+  open_cover:
+    service: switch.turn_on
+    target:
+      entity_id: switch.example_cover
+  close_cover:
+    service: switch.turn_off
+    target:
+      entity_id: switch.example_cover

--- a/home-assistant-config/templates/cover_templates.yaml
+++ b/home-assistant-config/templates/cover_templates.yaml
@@ -1,10 +1,50 @@
-example_cover:
-  friendly_name: "Example Cover"
+- name: "Volets (Tous)"
+  unique_id: "template_volets_tous"
+  device_class: shutter
+  state: "{{ is_state('cover.cover_volets_tous', 'open') }}"
   open_cover:
-    service: switch.turn_on
-    target:
-      entity_id: switch.example_cover
+    - service: cover.open_cover
+      target:
+        entity_id: cover.cover_volets_tous
   close_cover:
-    service: switch.turn_off
-    target:
-      entity_id: switch.example_cover
+    - service: cover.close_cover
+      target:
+        entity_id: cover.cover_volets_tous
+  stop_cover:
+    - service: cover.stop_cover
+      target:
+        entity_id: cover.cover_volets_tous
+
+- name: "Volets (RDC)"
+  unique_id: "template_volets_rdc"
+  device_class: shutter
+  state: "{{ is_state('cover.cover_volets_rdc', 'open') }}"
+  open_cover:
+    - service: cover.open_cover
+      target:
+        entity_id: cover.cover_volets_rdc
+  close_cover:
+    - service: cover.close_cover
+      target:
+        entity_id: cover.cover_volets_rdc
+  stop_cover:
+    - service: cover.stop_cover
+      target:
+        entity_id: cover.cover_volets_rdc
+
+- name: "Volets (Chambres)"
+  unique_id: "template_volets_chambres"
+  device_class: shutter
+  state: "{{ is_state('cover.cover_volets_chambres', 'open') }}"
+  open_cover:
+    - service: cover.open_cover
+      target:
+        entity_id: cover.cover_volets_chambres
+  close_cover:
+    - service: cover.close_cover
+      target:
+        entity_id: cover.cover_volets_chambres
+  stop_cover:
+    - service: cover.stop_cover
+      target:
+        entity_id: cover.cover_volets_chambres

--- a/home-assistant-config/templates/sensor_pac.yaml
+++ b/home-assistant-config/templates/sensor_pac.yaml
@@ -1,4 +1,0 @@
-sensor:
-  - name: "Example PAC Sensor"
-    unit_of_measurement: "°C"
-    state: "{{ 0 }}"

--- a/home-assistant-config/templates/sensor_pac.yaml
+++ b/home-assistant-config/templates/sensor_pac.yaml
@@ -1,0 +1,4 @@
+sensor:
+  - name: "Example PAC Sensor"
+    unit_of_measurement: "°C"
+    state: "{{ 0 }}"


### PR DESCRIPTION
## Summary
- move cover template configuration under `cover` domain with `platform: template`
- add example cover and group definitions
- provide example template sensor for PAC readings

## Testing
- `pip install --quiet yamllint` *(failed: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688fb9fdfc28832480fdfd8dbbf1cc11