### PR TITLE
Add dashboard views and templates

### DIFF
--- a/home-assistant-config/scripts.yaml
+++ b/home-assistant-config/scripts.yaml
@@ -1,0 +1,83 @@
+scenario_reveil:
+  alias: Scénario Réveil
+  sequence:
+    - service: cover.open_cover
+      target:
+        entity_id: cover.volets
+    - service: climate.turn_on
+      target:
+        entity_id:
+          - climate.adele
+          - climate.alex
+          - climate.bureau
+          - climate.cuisine
+          - climate.entree_tv
+          - climate.parents
+  mode: single
+
+scenario_coucher:
+  alias: Scénario Coucher
+  sequence:
+    - service: cover.close_cover
+      target:
+        entity_id: cover.volets
+    - service: climate.turn_off
+      target:
+        entity_id:
+          - climate.adele
+          - climate.alex
+          - climate.bureau
+          - climate.cuisine
+          - climate.entree_tv
+          - climate.parents
+  mode: single
+
+scenario_absent:
+  alias: Mode Absent
+  sequence:
+    - service: cover.close_cover
+      target:
+        entity_id: cover.volets
+    - service: switch.turn_off
+      target:
+        entity_id:
+          - switch.adele
+          - switch.alex
+          - switch.bureau
+          - switch.cuisine
+          - switch.entree_tv
+          - switch.parents
+    - service: climate.turn_off
+      target:
+        entity_id:
+          - climate.adele
+          - climate.alex
+          - climate.bureau
+          - climate.cuisine
+          - climate.entree_tv
+          - climate.parents
+  mode: single
+
+scenario_fete:
+  alias: Mode Fête
+  sequence:
+    - service: light.turn_on
+      target:
+        entity_id: light.connectivity_kit_ledbox
+  mode: single
+
+scenario_soiree_film:
+  alias: Scénario Soirée Film
+  sequence:
+    - service: automation.trigger
+      target:
+        entity_id: automation.soiree_film
+  mode: single
+
+scenario_nuit:
+  alias: Scénario Nuit
+  sequence:
+    - service: automation.trigger
+      target:
+        entity_id: automation.nuit
+  mode: single

--- a/lovelace/button_card_templates.yaml
+++ b/lovelace/button_card_templates.yaml
@@ -1,0 +1,168 @@
+# Templates pour les boutons de navigation et contrôle
+
+climate-button:
+  aspect_ratio: 1/1
+  size: 100%
+  show_state: true
+  show_name: true
+  show_icon: true
+  styles:
+    card:
+      - background: rgba(255, 255, 255, 0.15)
+      - backdrop-filter: blur(10px)
+      - border-radius: 16px
+      - border: 1px solid rgba(255, 255, 255, 0.2)
+      - padding: 8px
+    icon:
+      - width: 24px
+      - height: 24px
+      - color: var(--primary-color)
+    name:
+      - font-size: 11px
+      - font-weight: 500
+      - color: var(--primary-text-color)
+    state:
+      - font-size: 10px
+      - color: var(--secondary-text-color)
+  tap_action:
+    action: more-info
+  custom_fields:
+    temperature: |
+      [[[ 
+        if (variables.climate_entity) {
+          const temp = states[variables.climate_entity].attributes.current_temperature;
+          return temp ? `${temp}°C` : 'N/A';
+        }
+        return '';
+      ]]]
+  state:
+    - value: 'heat'
+      styles:
+        card:
+          - background: rgba(255, 152, 0, 0.2)
+    - value: 'cool'
+      styles:
+        card:
+          - background: rgba(33, 150, 243, 0.2)
+
+piece-button:
+  aspect_ratio: 1/1
+  size: 100%
+  show_state: false
+  show_name: true
+  styles:
+    card:
+      - background: linear-gradient(135deg, rgba(227, 159, 112, 0.9), rgba(157, 58, 102, 0.8))
+      - color: white
+      - border-radius: 16px
+      - border: 2px solid rgba(227, 159, 112, 0.7)
+      - padding: 8px
+      - transition: all 0.3s ease
+    icon:
+      - width: 32px
+      - height: 32px
+      - color: white
+    name:
+      - font-size: 13px
+      - font-weight: 500
+      - color: white
+  state:
+    - value: hover
+      styles:
+        card:
+          - transform: scale(1.05)
+          - box-shadow: 0 8px 24px rgba(227, 159, 112, 0.4)
+
+materiel-button:
+  aspect_ratio: 1/1
+  size: 100%
+  show_state: false
+  show_name: true
+  styles:
+    card:
+      - background: linear-gradient(135deg, rgba(157, 58, 102, 0.9), rgba(227, 159, 112, 0.8))
+      - color: white
+      - border-radius: 16px
+      - border: 2px solid rgba(157, 58, 102, 0.7)
+      - padding: 8px
+      - transition: all 0.3s ease
+    icon:
+      - width: 32px
+      - height: 32px
+      - color: white
+    name:
+      - font-size: 13px
+      - font-weight: 500
+      - color: white
+  state:
+    - value: hover
+      styles:
+        card:
+          - transform: scale(1.05)
+
+scenario-button:
+  aspect_ratio: 1/1
+  size: 100%
+  show_state: false
+  show_name: true
+  styles:
+    card:
+      - background: linear-gradient(135deg, rgba(76, 175, 80, 0.9), rgba(139, 195, 74, 0.8))
+      - color: white
+      - border-radius: 16px
+      - border: 2px solid rgba(76, 175, 80, 0.7)
+      - padding: 8px
+      - transition: all 0.3s ease
+    icon:
+      - width: 32px
+      - height: 32px
+      - color: white
+    name:
+      - font-size: 13px
+      - font-weight: 500
+      - color: white
+  state:
+    - value: hover
+      styles:
+        card:
+          - transform: scale(1.05)
+
+nav-button:
+  aspect_ratio: 1/1
+  size: 100%
+  show_state: false
+  show_name: true
+  styles:
+    card:
+      - background: rgba(227,159,112,0.9)
+      - color: white
+      - border-radius: 16px
+      - padding: 8px
+    icon:
+      - width: 32px
+      - height: 32px
+    name:
+      - font-size: 13px
+      - font-weight: 500
+  state:
+    - value: hover
+      styles:
+        card:
+          - transform: scale(1.05)
+
+control-card:
+  aspect_ratio: 1/1
+  size: 100%
+  show_state: true
+  show_name: true
+  styles:
+    card:
+      - background: rgba(245,245,245,0.8)
+      - border-radius: 20px
+      - padding: 12px
+    icon:
+      - width: 36px
+      - height: 36px
+    name:
+      - font-size: 14px
+      - color: var(--primary-text-color)

--- a/ui_dashboard.yaml
+++ b/ui_dashboard.yaml
@@ -32,8 +32,7 @@ views:
 
                     *{{ now().strftime('%A %d %B %Y') }} - Maison connectée*
 
-                    **🌡️ {{ states('sensor.temp_salon') }}°C** • **⚡ {{
-                    states('sensor.consommation_electrique') }}W**
+                    **🌡️ {{ state_attr('weather.forecast_maison','temperature') }}°C** • **📡 {{ states('sensor.freebox_download_speed') }} kB/s**
                   card_mod:
                     class: transparent-card welcome-card
                 - type: custom:button-card
@@ -265,7 +264,7 @@ views:
                           - background: >-
                               linear-gradient(135deg, rgba(244, 67, 54, 0.9),
                               rgba(233, 30, 99, 0.8))
-                          - border: 2px solid rgba(244, 67, 54, 0.8)
+                      - border: 2px solid rgba(244, 67, 54, 0.8)
                     - type: custom:button-card
                       template: scenario-button
                       name: 🎉 Fête
@@ -275,4 +274,544 @@ views:
                         service: script.scenario_fete
                         confirmation:
                           text: Lancer le mode fête ?
+                      styles:
+                        card:
+                          - background: >-
+                              linear-gradient(135deg, rgba(156, 39, 176, 0.9), rgba(233, 30, 99, 0.8))
+                          - border: 2px solid rgba(156, 39, 176, 0.8)
+                    - type: custom:button-card
+                      template: scenario-button
+                      name: 🎥 Soirée Film
+                      icon: mdi:movie
+                      tap_action:
+                        action: call-service
+                        service: script.scenario_soiree_film
+                        confirmation:
+                          text: Lancer le scénario soirée film ?
+                      styles:
+                        card:
+                          - background: >-
+                              linear-gradient(135deg, rgba(0, 150, 136, 0.9), rgba(0, 188, 212, 0.8))
+                          - border: 2px solid rgba(0, 150, 136, 0.8)
+                    - type: custom:button-card
+                      template: scenario-button
+                      name: 🌌 Nuit
+                      icon: mdi:power-sleep
+                      tap_action:
+                        action: call-service
+                        service: script.scenario_nuit
+                        confirmation:
+                          text: Lancer le scénario nuit ?
+                      styles:
+                        card:
+                          - background: >-
+                              linear-gradient(135deg, rgba(33, 33, 33, 0.9), rgba(66, 66, 66, 0.8))
+                          - border: 2px solid rgba(33, 33, 33, 0.8)
+    badges: []
+
+  - title: Pièces
+    path: pieces
+    icon: mdi:floor-plan
+    theme: alforis-tablette
+    background:
+      image: /local/fond_tablette.webp
+      size: cover
+      alignment: center
+      repeat: no-repeat
+      attachment: fixed
+    cards:
+      - type: grid
+        columns: 2
+        square: false
+        cards:
+          - type: custom:button-card
+            template: climate-button
+            name: "👧 Adèle"
+            entity: climate.adele
+            tap_action:
+              action: navigate
+              navigation_path: /lovelace/adele
+          - type: custom:button-card
+            template: climate-button
+            name: "👦 Alex"
+            entity: climate.alex
+            tap_action:
+              action: navigate
+              navigation_path: /lovelace/alex
+          - type: custom:button-card
+            template: climate-button
+            name: "💼 Bureau"
+            entity: climate.bureau
+            tap_action:
+              action: navigate
+              navigation_path: /lovelace/bureau
+          - type: custom:button-card
+            template: climate-button
+            name: "🍳 Cuisine"
+            entity: climate.cuisine
+            tap_action:
+              action: navigate
+              navigation_path: /lovelace/cuisine
+          - type: custom:button-card
+            template: climate-button
+            name: "📺 Entrée & TV"
+            entity: climate.entree_tv
+            tap_action:
+              action: navigate
+              navigation_path: /lovelace/entree_tv
+          - type: custom:button-card
+            template: climate-button
+            name: "🛏️ Parents"
+            entity: climate.parents
+            tap_action:
+              action: navigate
+              navigation_path: /lovelace/parents
+    badges: []
+
+  - title: Matériel
+    path: materiel
+    icon: mdi:tools
+    theme: alforis-tablette
+    background:
+      image: /local/fond_tablette.webp
+      size: cover
+      alignment: center
+      repeat: no-repeat
+      attachment: fixed
+    cards:
+      - type: grid
+        columns: 2
+        square: false
+        cards:
+          - type: custom:button-card
+            template: materiel-button
+            name: "🪟 Volets"
+            icon: mdi:window-shutter
+            tap_action:
+              action: more-info
+            entity: cover.volets
+          - type: custom:button-card
+            template: materiel-button
+            name: "🌡️ Température"
+            icon: mdi:thermometer
+            tap_action:
+              action: more-info
+            entity: weather.forecast_maison
+          - type: custom:button-card
+            template: materiel-button
+            name: "🔌 Électroménager"
+            icon: mdi:washing-machine
+            tap_action:
+              action: more-info
+            entity: switch.lave_vaisselle_etat
+          - type: custom:button-card
+            template: materiel-button
+            name: "🌿 Extérieur"
+            icon: mdi:pine-tree
+            tap_action:
+              action: more-info
+            entity: binary_sensor.irrigation_unlimited_c1_m
+          - type: custom:button-card
+            template: materiel-button
+            name: "📶 Réseau"
+            icon: mdi:router-network
+            tap_action:
+              action: navigate
+              navigation_path: /lovelace/reseau
+          - type: custom:button-card
+            template: materiel-button
+            name: "🖨️ Imprimante"
+            icon: mdi:printer
+            tap_action:
+              action: navigate
+              navigation_path: /lovelace/imprimante
+    badges: []
+
+  - title: RDC
+    path: rdc
+    icon: mdi:home-floor-0
+    theme: alforis-tablette
+    background:
+      image: /local/fond_tablette.webp
+      size: cover
+      alignment: center
+      repeat: no-repeat
+      attachment: fixed
+    cards:
+      - type: grid
+        columns: 2
+        square: false
+        cards:
+          - type: custom:button-card
+            template: climate-button
+            name: "🍳 Cuisine"
+            entity: climate.cuisine
+          - type: custom:button-card
+            template: climate-button
+            name: "📺 Entrée & TV"
+            entity: climate.entree_tv
+      - type: entities
+        title: "Volets RDC"
+        entities:
+          - cover.volets_rdc_2
+    badges: []
+
+  - title: R+1
+    path: etage1
+    icon: mdi:home-floor-1
+    theme: alforis-tablette
+    background:
+      image: /local/fond_tablette.webp
+      size: cover
+      alignment: center
+      repeat: no-repeat
+      attachment: fixed
+    cards:
+      - type: grid
+        columns: 2
+        square: false
+        cards:
+          - type: custom:button-card
+            template: climate-button
+            name: "👧 Adèle"
+            entity: climate.adele
+          - type: custom:button-card
+            template: climate-button
+            name: "👦 Alex"
+            entity: climate.alex
+          - type: custom:button-card
+            template: climate-button
+            name: "💼 Bureau"
+            entity: climate.bureau
+          - type: custom:button-card
+            template: climate-button
+            name: "🛏️ Parents"
+            entity: climate.parents
+      - type: entities
+        title: "Volets Chambres"
+        entities:
+          - cover.volets_chambres_2
+    badges: []
+
+  - title: R+2
+    path: etage2
+    icon: mdi:home-floor-2
+    theme: alforis-tablette
+    background:
+      image: /local/fond_tablette.webp
+      size: cover
+      alignment: center
+      repeat: no-repeat
+      attachment: fixed
+    cards:
+      - type: custom:button-card
+        template: climate-button
+        name: "Chambres"
+        entity: climate.chambres
+    badges: []
+
+  - title: Volets
+    path: volets
+    icon: mdi:window-shutter
+    theme: alforis-tablette
+    background:
+      image: /local/fond_tablette.webp
+      size: cover
+      alignment: center
+      repeat: no-repeat
+      attachment: fixed
+    cards:
+      - type: entities
+        title: "Gestion des volets"
+        entities:
+          - cover.tous_les_volets
+          - cover.volets_rdc_2
+          - cover.volets_chambres_2
+    badges: []
+
+  - title: Température
+    path: temperature
+    icon: mdi:thermometer
+    theme: alforis-tablette
+    background:
+      image: /local/fond_tablette.webp
+      size: cover
+      alignment: center
+      repeat: no-repeat
+      attachment: fixed
+    cards:
+      - type: entities
+        title: "Températures"
+        entities:
+          - sensor.adele_temperature
+          - sensor.alex_temperature
+          - sensor.bureau_temperature
+          - sensor.cuisine_temperature
+          - sensor.entree_tv_temperature
+          - sensor.parents_temperature
+    badges: []
+
+  - title: Électroménager
+    path: electromenager
+    icon: mdi:washing-machine
+    theme: alforis-tablette
+    background:
+      image: /local/fond_tablette.webp
+      size: cover
+      alignment: center
+      repeat: no-repeat
+      attachment: fixed
+    cards:
+      - type: entities
+        title: "Lave-vaisselle"
+        entities:
+          - switch.lave_vaisselle_etat
+          - sensor.lave_vaisselle_etat
+          - sensor.lave_vaisselle_porte
+      - type: entities
+        title: "Table de cuisson"
+        entities:
+          - switch.table_de_cuisson_etat
+          - switch.table_de_cuisson_securite_enfant
+          - sensor.table_de_cuisson_etat
+    badges: []
+
+  - title: Extérieur
+    path: exterieur
+    icon: mdi:pine-tree
+    theme: alforis-tablette
+    background:
+      image: /local/fond_tablette.webp
+      size: cover
+      alignment: center
+      repeat: no-repeat
+      attachment: fixed
+    cards:
+      - type: entities
+        title: "Arrosage"
+        entities:
+          - binary_sensor.irrigation_unlimited_c1_m
+          - binary_sensor.irrigation_unlimited_c1_z1
+          - binary_sensor.irrigation_unlimited_c1_z2
+          - binary_sensor.irrigation_unlimited_c1_z3
+      - type: weather-forecast
+        entity: weather.forecast_maison
+        show_current: true
+        show_forecast: true
+        forecast_type: daily
+    badges: []
+
+  - title: Réseau
+    path: reseau
+    icon: mdi:router-network
+    theme: alforis-tablette
+    background:
+      image: /local/fond_tablette.webp
+      size: cover
+      alignment: center
+      repeat: no-repeat
+      attachment: fixed
+    cards:
+      - type: entities
+        title: "Freebox"
+        entities:
+          - device_tracker.freebox_v9_r1
+          - sensor.freebox_download_speed
+          - sensor.freebox_upload_speed
+          - sensor.freebox_temperature_cpu_0
+      - type: entities
+        title: "Appareils connectés"
+        entities:
+          - device_tracker.imx6ull14x14evk
+          - device_tracker.iphone_9
+          - device_tracker.samsung
+    badges: []
+
+  - title: Imprimante
+    path: imprimante
+    icon: mdi:printer
+    theme: alforis-tablette
+    background:
+      image: /local/fond_tablette.webp
+      size: cover
+      alignment: center
+      repeat: no-repeat
+      attachment: fixed
+    cards:
+      - type: entities
+        title: "HP DeskJet 3700"
+        entities:
+          - sensor.hp_deskjet_3700_series
+          - sensor.hp_deskjet_3700_series_black_ink
+          - sensor.hp_deskjet_3700_series_tri_color_ink
+    badges: []
+
+  - title: Chambre Adèle
+    path: adele
+    icon: mdi:account-child
+    theme: alforis-tablette
+    background:
+      image: /local/fond_tablette.webp
+      size: cover
+      alignment: center
+      repeat: no-repeat
+      attachment: fixed
+    cards:
+      - type: custom:button-card
+        template: climate-button
+        name: "Climat Adèle"
+        entity: climate.adele
+      - type: entities
+        title: "Volets"
+        entities:
+          - cover.fenetre_adele_arriere
+          - cover.fenetre_adele_ru
+      - type: entities
+        title: "Capteurs"
+        entities:
+          - sensor.adele_temperature
+          - sensor.adele_humidite
+          - binary_sensor.adele_probleme
+    badges: []
+
+  - title: Chambre Alex
+    path: alex
+    icon: mdi:account-child
+    theme: alforis-tablette
+    background:
+      image: /local/fond_tablette.webp
+      size: cover
+      alignment: center
+      repeat: no-repeat
+      attachment: fixed
+    cards:
+      - type: custom:button-card
+        template: climate-button
+        name: "Climat Alex"
+        entity: climate.alex
+      - type: entities
+        title: "Volets"
+        entities:
+          - cover.fenetre_alex_jar
+          - cover.fenetre_alex_rue
+      - type: entities
+        title: "Capteurs"
+        entities:
+          - sensor.alex_temperature
+          - sensor.alex_humidite
+          - binary_sensor.alex_probleme
+    badges: []
+
+  - title: Bureau
+    path: bureau
+    icon: mdi:briefcase
+    theme: alforis-tablette
+    background:
+      image: /local/fond_tablette.webp
+      size: cover
+      alignment: center
+      repeat: no-repeat
+      attachment: fixed
+    cards:
+      - type: custom:button-card
+        template: climate-button
+        name: "Climat Bureau"
+        entity: climate.bureau
+      - type: entities
+        title: "Volets"
+        entities:
+          - cover.fenetre_bureau
+      - type: entities
+        title: "Capteurs"
+        entities:
+          - sensor.bureau_temperature
+          - sensor.bureau_humidite
+          - binary_sensor.bureau_probleme
+    badges: []
+
+  - title: Cuisine
+    path: cuisine
+    icon: mdi:pot-mix
+    theme: alforis-tablette
+    background:
+      image: /local/fond_tablette.webp
+      size: cover
+      alignment: center
+      repeat: no-repeat
+      attachment: fixed
+    cards:
+      - type: custom:button-card
+        template: climate-button
+        name: "Climat Cuisine"
+        entity: climate.cuisine
+      - type: entities
+        title: "Volets"
+        entities:
+          - cover.fenetre_cuisine
+          - cover.fenetre_cuisine_avant
+      - type: entities
+        title: "Capteurs"
+        entities:
+          - sensor.cuisine_temperature
+          - sensor.cuisine_humidite
+          - binary_sensor.cuisine_probleme
+    badges: []
+
+  - title: Entrée & TV
+    path: entree_tv
+    icon: mdi:television
+    theme: alforis-tablette
+    background:
+      image: /local/fond_tablette.webp
+      size: cover
+      alignment: center
+      repeat: no-repeat
+      attachment: fixed
+    cards:
+      - type: custom:button-card
+        template: climate-button
+        name: "Climat Entrée & TV"
+        entity: climate.entree_tv
+      - type: entities
+        title: "Volets"
+        entities:
+          - cover.fenetre_entree
+          - cover.fenetre_salon_central
+          - cover.fenetre_salon_dr
+          - cover.fenetre_salon_gauche
+          - cover.fenetre_salon_tv
+      - type: entities
+        title: "Capteurs"
+        entities:
+          - sensor.entree_tv_temperature
+          - sensor.entree_tv_humidite
+          - binary_sensor.entree_tv_probleme
+    badges: []
+
+  - title: Suite Parents
+    path: parents
+    icon: mdi:bed-king
+    theme: alforis-tablette
+    background:
+      image: /local/fond_tablette.webp
+      size: cover
+      alignment: center
+      repeat: no-repeat
+      attachment: fixed
+    cards:
+      - type: custom:button-card
+        template: climate-button
+        name: "Climat Parents"
+        entity: climate.parents
+      - type: entities
+        title: "Volets"
+        entities:
+          - cover.fenetre_sdb_suite
+          - cover.fenetre_suite
+      - type: entities
+        title: "Capteurs"
+        entities:
+          - sensor.parents_temperature
+          - sensor.parents_humidite
+          - binary_sensor.parents_probleme
     badges: []


### PR DESCRIPTION
## Summary
- add reusable button card templates
- define scripts for wake, sleep, away and party scenarios
- extend UI dashboard with room and equipment views
- expand dashboard with network/printer views and per-room pages
- restore gradient-styled button card templates

## Testing
- `pip install yamllint` *(fails: Could not find a version that satisfies the requirement yamllint (ProxyError 403))*
- `pip install pyyaml` *(fails: Could not find a version that satisfies the requirement pyyaml (ProxyError 403))*
- `yamllint ui_dashboard.yaml` *(fails: command not found: yamllint)*
- `python - <<'PY'\nimport yaml\nPY` *(fails: ModuleNotFoundError: No module named 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_688fbb57457483248901c57ffb9a9b22